### PR TITLE
fix multiple start on darwin

### DIFF
--- a/examples/multiagentexamplechainer.py
+++ b/examples/multiagentexamplechainer.py
@@ -67,7 +67,7 @@ def main():
 
     env.init(**config)
 
-    obs_size = 84 * 84 * 3  # env.observation_space.shape[0]
+    obs_size = 84 * 84 * 3
     n_actions = env.action_space.n
     q_func = QFunction(obs_size, n_actions)
 

--- a/marlo/envs/minecraft_env.py
+++ b/marlo/envs/minecraft_env.py
@@ -8,6 +8,8 @@ import xml.etree.ElementTree as ET
 import gym
 from gym import spaces, error
 
+reshape = False
+
 try:
     import malmo.MalmoPython as MalmoPython
 except ImportError as e:
@@ -365,7 +367,8 @@ class MinecraftEnv(gym.Env):
             frame = world_state.video_frames[0]
 
             image = np.frombuffer(frame.pixels, dtype=np.uint8)
-            image = image.reshape((frame.height, frame.width, frame.channels))
+            if reshape:
+                image = image.reshape((frame.height, frame.width, frame.channels))
             logger.debug(image)
             self.last_image = image
         else:

--- a/marlo/envs/minecraft_env.py
+++ b/marlo/envs/minecraft_env.py
@@ -297,8 +297,8 @@ class MinecraftEnv(gym.Env):
                     logger.error("Error starting mission: "+str(e))
                     raise
                 else:
-                    logger.warn("Error starting mission: "+str(e))
-                    logger.info("Sleeping for %d seconds...", self.retry_sleep)
+                    logger.warn("On starting mission: "+str(e))
+                    logger.warn("Will retry after %d seconds...", self.retry_sleep)
                     time.sleep(self.retry_sleep)
 
         # Loop until mission starts:

--- a/marlo/envs/minecraft_env.py
+++ b/marlo/envs/minecraft_env.py
@@ -1,7 +1,7 @@
 import logging
 import time
 import os
-
+from pathlib import Path
 import numpy as np
 import json
 import xml.etree.ElementTree as ET
@@ -26,6 +26,13 @@ SINGLE_DIRECTION_DISCRETE_MOVEMENTS = [ "jumpeast", "jumpnorth", "jumpsouth", "j
 
 MULTIPLE_DIRECTION_DISCRETE_MOVEMENTS = [ "move", "turn", "look", "strafe",
                                           "jumpmove", "jumpstrafe" ]
+
+
+class InvalidMissionFile(Exception):
+    def __init__(self, file_name):
+        self.file_name = file_name
+
+
 class TurnState(object):
     def __init__(self):
         self._turn_key = None
@@ -51,6 +58,7 @@ class TurnState(object):
     def has_played(self, value):
         self._has_played = bool(value)
 
+
 class MinecraftEnv(gym.Env):
     metadata = {'render.modes': ['human', 'rgb_array']}
 
@@ -58,8 +66,16 @@ class MinecraftEnv(gym.Env):
         super(MinecraftEnv, self).__init__()
 
         self.agent_host = MalmoPython.AgentHost()
-        assets_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../assets')
-        self.mission_file = os.path.join(assets_dir, mission_file)
+
+        # Allow full paths for mission files.
+        if Path(mission_file).is_file():
+            self.mission_file = mission_file
+        else:
+            assets_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../assets')
+            self.mission_file = os.path.join(assets_dir, mission_file)
+            if not Path(self.mission_file).is_file():
+                raise InvalidMissionFile(mission_file)
+
         self.load_mission_file(self.mission_file)
 
         self.client_pool = None
@@ -349,7 +365,7 @@ class MinecraftEnv(gym.Env):
             frame = world_state.video_frames[0]
 
             image = np.frombuffer(frame.pixels, dtype=np.uint8)
-            # image = image.reshape((frame.height, frame.width, frame.channels))
+            image = image.reshape((frame.height, frame.width, frame.channels))
             logger.debug(image)
             self.last_image = image
         else:

--- a/marlo/launch_minecraft_in_background.py
+++ b/marlo/launch_minecraft_in_background.py
@@ -59,11 +59,12 @@ def launch_minecraft_in_background(minecraft_path, ports=None, timeout=360, repl
             # (Launching a process to run the terminal app to run a small launch script to run
             # the launchClient script to run Minecraft... is it possible that this is not the most
             # straightforward way to go about things?)
-            tmp_file = open("/tmp/launcher.sh", "w")
+            launcher_file = "/tmp/launcher_" + os.getpid() + ".sh"
+            tmp_file = open(launcher_file, "w")
             tmp_file.write(minecraft_path + '/launchClient.sh -port ' + str(port) + replaceable_arg)
             tmp_file.close()
-            os.chmod("/tmp/launcher.sh", 0o777)
-            p = subprocess.Popen(['open', '-a', 'Terminal.app', '/tmp/launcher.sh'])
+            os.chmod(launcher_file, 0o700)
+            p = subprocess.Popen(['open', '-a', 'Terminal.app', launcher_file])
         else:
             p = subprocess.Popen(minecraft_path + "/launchClient.sh -port " + str(port) + replaceable_arg,
                              close_fds=True, shell=True,


### PR DESCRIPTION
Fix the Darwin launching from multiple processes potential issue.

Allow mission files to be outside the "assets" dir. Made it easier to test out the samples being prepared for comp.

Still  need to decide if env reshapes the image array but think we don't need to to avoid any np.flatten().