### PR TITLE
can handle a mission.xml file without VideoProducer elements

### DIFF
--- a/marlo/base_env_builder.py
+++ b/marlo/base_env_builder.py
@@ -577,8 +577,14 @@ class MarloEnvBuilderBase(gym.Env):
                     vp = ElementTree.Element(ns + "VideoProducer")
                     e.append(vp)
                 w = vp.find(ns + "Width")
+                if w is None:
+                    w = ElementTree.Element(ns + "Width")
+                    vp.append(w)
                 w.text = str(params.videoResolution[0] if params.videoResolution else '800')
                 h = vp.find(ns + "Height")
+                if h is None:
+                    h = ElementTree.Element(ns + "Height")
+                    vp.append(h)
                 h.text = str(params.videoResolution[1] if params.videoResolution else '600')
                 if params.videoWithDepth is not None:
                     vp.attrib['want_depth'] = 'true' if params.videoWithDepth else 'false'


### PR DESCRIPTION
When mission.xml does not includes VideoProducer elements, marlo.make stops with errors in the current version.

Even the following simple program causes an error.
`
import marlo
marlo.make('MarLo-MazeRunner-v0')
`

This PR fixes the problem.